### PR TITLE
Rearrange Alojamiento section with content on left and image on right

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,20 +130,15 @@
 
     <main>
         <section id="alojamiento" class="section main-alojamiento-section" tabindex="-1">
-            <h2>Alojamiento</h2>
-            <p class="section-description">Ofrecemos alojamiento para parejas y para grupos. Disfruta del paisaje de montañas mientras te hospedas rodeado de orquídeas, viñedos, árboles de cacao, río, piscina, jacuzzi y aves endémicas.</p>
-            <div class="accommodation-options">
-                <div class="option">
-                    <img src="assets/images/home/section1-accommodation1.jpg" alt="Alojamiento para parejas en Finca Termópilas">
-                    <h3>Parejas</h3>
+            <div class="alojamiento-container">
+                <div class="alojamiento-content">
+                    <h2>Alojamiento</h2>
+                    <p class="section-description">Disfruta del paisaje de montañas mientras te hospedas rodeado de orquídeas, viñedos, árboles de cacao, río, piscina, jacuzzi y aves endémicas.</p>
+                    <a href="rooms.html" class="cta-button">Ver todas las habitaciones</a>
                 </div>
-                <div class="option">
-                    <img src="assets/images/home/section1-accommodation2.jpg" alt="Alojamiento para grupos en Finca Termópilas">
-                    <h3>Grupos</h3>
+                <div class="alojamiento-image">
+                    <img src="assets/images/home/section1-accommodation1.jpg" alt="Alojamiento en Finca Termópilas">
                 </div>
-            </div>
-            <div class="text-center mt-2">
-                <a href="rooms.html" class="cta-button">Ver todas las habitaciones</a>
             </div>
         </section>
 

--- a/styles/main-sections.css
+++ b/styles/main-sections.css
@@ -6,6 +6,60 @@
     color: var(--text-color);
 }
 
+.alojamiento-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 3rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.alojamiento-content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.alojamiento-content h2 {
+    text-align: left;
+    margin-bottom: 1.5rem;
+}
+
+.alojamiento-content h2::after {
+    left: 0;
+    transform: none;
+}
+
+.alojamiento-content .section-description {
+    text-align: left;
+    margin-left: 0;
+    margin-right: 0;
+}
+
+.alojamiento-content .cta-button {
+    margin-top: 1.5rem;
+}
+
+.alojamiento-image {
+    flex: 1;
+    max-width: 500px;
+}
+
+.alojamiento-image img {
+    width: 100%;
+    height: 500px;
+    object-fit: cover;
+    aspect-ratio: 1/1;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+    transition: transform 0.3s ease;
+}
+
+.alojamiento-image img:hover {
+    transform: scale(1.02);
+}
+
 /* Vino y Cacao Section */
 .main-productos-section {
     background-color: #504128;

--- a/styles/responsive.css
+++ b/styles/responsive.css
@@ -1,0 +1,38 @@
+/* Responsive styles for Alojamiento section */
+@media (max-width: 768px) {
+    .alojamiento-container {
+        flex-direction: column-reverse;
+        gap: 2rem;
+    }
+    
+    .alojamiento-content {
+        width: 100%;
+    }
+    
+    .alojamiento-content h2 {
+        text-align: center;
+        margin-top: 1.5rem;
+    }
+    
+    .alojamiento-content h2::after {
+        left: 50%;
+        transform: translateX(-50%);
+    }
+    
+    .alojamiento-content .section-description {
+        text-align: center;
+    }
+    
+    .alojamiento-content .cta-button {
+        align-self: center;
+    }
+    
+    .alojamiento-image {
+        width: 100%;
+        max-width: 100%;
+    }
+    
+    .alojamiento-image img {
+        height: 350px;
+    }
+} 


### PR DESCRIPTION
This PR rearranges the Alojamiento section to have the header, text, and button on the left and the image squared on the right. It also adds responsive styles to ensure the layout works well on mobile devices.