### PR TITLE
Add Google Analytics to all HTML pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2406CNRCX9"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-2406CNRCX9');
+    </script>
     <title>Página no encontrada - Finca Termópilas</title>
     <link rel="stylesheet" href="styles/main.css">
     <link rel="stylesheet" href="styles/hero.css">

--- a/icon-generator.html
+++ b/icon-generator.html
@@ -3,6 +3,14 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2406CNRCX9"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-2406CNRCX9');
+    </script>
     <title>Icon Generator for Finca Termópilas</title>
     <style>
         body {

--- a/index.html
+++ b/index.html
@@ -8,6 +8,16 @@
     <meta name="keywords" content="Finca Termópilas, alojamiento Huila, vino artesanal, cacao, eventos Rivera, pasadía, retiros, turismo Huila">
     <meta name="author" content="Finca Termópilas">
     
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2406CNRCX9"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-2406CNRCX9');
+    </script>
+    
     <!-- Preconnect to Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/rooms.html
+++ b/rooms.html
@@ -8,6 +8,16 @@
     <meta name="keywords" content="Finca Termópilas, habitaciones Huila, alojamiento de lujo, Rivera, habitaciones con vista">
     <meta name="author" content="Finca Termópilas">
     
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2406CNRCX9"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-2406CNRCX9');
+    </script>
+    
     <!-- Favicon -->
     <link rel="icon" href="assets/icons/favicon.ico" type="image/x-icon">
     

--- a/tour-vino-cacao.html
+++ b/tour-vino-cacao.html
@@ -8,6 +8,16 @@
     <meta name="keywords" content="Tour de Vino, Cacao, Chocolate, Finca Termópilas, Rivera, Huila, experiencia sensorial, viñedos, degustación">
     <meta name="author" content="Finca Termópilas">
     
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2406CNRCX9"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-2406CNRCX9');
+    </script>
+    
     <!-- Preconnect to Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
This PR adds Google Analytics tracking (ID: G-2406CNRCX9) to all HTML pages of the website, including index.html, rooms.html, tour-vino-cacao.html, 404.html, and icon-generator.html. The tracking code has been placed in the head section of each file, right after the meta tags.