### PR TITLE
feat: add /despierta vanity URL

### DIFF
--- a/despierta.html
+++ b/despierta.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="es-CO">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Despierta Tu Ser - Redirigiendo...</title>
+
+    <!-- 301 Redirect via meta refresh (GitHub Pages doesn't support .htaccess) -->
+    <meta http-equiv="refresh" content="0; url=https://eventos.termopilas.co/despierta">
+    <link rel="canonical" href="https://eventos.termopilas.co/despierta">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://termopilas.co/despierta.html">
+    <meta property="og:title" content="Despierta Tu Ser - Finca Termópilas">
+    <meta property="og:description" content="Experiencia de conexión espiritual con numerología, carta astral básica, intención de luna nueva, meditación guiada y fogata en Finca Termópilas, Rivera, Huila.">
+    <meta property="og:image" content="https://termopilas.co/assets/images/tour/tour-hero.jpg">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://termopilas.co/despierta.html">
+    <meta property="twitter:title" content="Despierta Tu Ser - Finca Termópilas">
+    <meta property="twitter:description" content="Experiencia de conexión espiritual con numerología, carta astral básica, intención de luna nueva, meditación guiada y fogata en Finca Termópilas, Rivera, Huila.">
+    <meta property="twitter:image" content="https://termopilas.co/assets/images/tour/tour-hero.jpg">
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2406CNRCX9"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-2406CNRCX9');
+    </script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+        !function(f,b,e,v,n,t,s)
+        {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+        n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+        if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+        n.queue=[];t=b.createElement(e);t.async=!0;
+        t.src=v;s=b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t,s)}(window, document,'script',
+        'https://connect.facebook.net/en_US/fbevents.js');
+        fbq('init', '760911966545667');
+        fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+    src="https://www.facebook.com/tr?id=760911966545667&ev=PageView&noscript=1"
+    /></noscript>
+
+    <!-- Favicon -->
+    <link rel="icon" href="assets/images/favicon.png" type="image/png">
+
+    <!-- PWA Manifest -->
+    <link rel="manifest" href="/manifest.json">
+    <meta name="theme-color" content="#F29F05">
+
+    <!-- Apple Touch Icon -->
+    <link rel="apple-touch-icon" href="/assets/images/icons/apple-touch-icon.png">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="Termópilas">
+
+    <!-- Microsoft Tiles -->
+    <meta name="msapplication-TileColor" content="#F29F05">
+    <meta name="msapplication-TileImage" content="/assets/images/icons/icon-144x144.png">
+
+    <style>
+        body {
+            font-family: 'Montserrat', sans-serif;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            text-align: center;
+            padding: 20px;
+        }
+        .redirect-message {
+            max-width: 600px;
+        }
+        h1 {
+            font-size: 2rem;
+            margin-bottom: 1rem;
+        }
+        p {
+            font-size: 1.2rem;
+            margin-bottom: 2rem;
+        }
+        .spinner {
+            border: 4px solid rgba(255, 255, 255, 0.3);
+            border-radius: 50%;
+            border-top: 4px solid white;
+            width: 50px;
+            height: 50px;
+            animation: spin 1s linear infinite;
+            margin: 0 auto;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+        a {
+            color: white;
+            text-decoration: underline;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <div class="redirect-message">
+        <h1>✨ Despierta Tu Ser</h1>
+        <p>Redirigiendo a nuestra página de eventos...</p>
+        <div class="spinner"></div>
+        <p style="margin-top: 2rem; font-size: 1rem;">
+            Si no eres redirigido automáticamente,
+            <a href="https://eventos.termopilas.co/despierta">haz clic aquí</a>
+        </p>
+    </div>
+
+    <script>
+        window.location.replace('https://eventos.termopilas.co/despierta');
+    </script>
+</body>
+</html>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -29,6 +29,7 @@ const PRIMARY_PAGES = new Set([
   'salon.html',
   'catalogo.html',
   'cata.html',
+  'despierta.html',
   'pago.html',
 ]);
 
@@ -128,6 +129,7 @@ const PAGE_IMAGE_MAP = {
   'salon.html': 'assets/images/venue/image1.png',
   'catalogo.html': 'assets/images/catalog/header.png',
   'cata.html': 'assets/images/tour/tour-wine.jpg',
+  'despierta.html': 'assets/images/tour/header.png',
   'pago.html': 'assets/images/pago/wompi.png',
   'galeria.html': 'assets/images/galeria/galeria-01.jpeg',
   'blog.html': 'assets/images/blog/header.png',

--- a/service-worker.js
+++ b/service-worker.js
@@ -14,6 +14,7 @@ const urlsToCache = [
   '/catalogo.html',
   '/coliving.html',
   '/coliving/gracias.html',
+  '/despierta.html',
   '/dist/main.js',
   '/feedback.html',
   '/galeria.html',

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://termopilas.co/</loc>
-    <lastmod>2026-03-22T13:44:40+00:00</lastmod>
+    <lastmod>2026-04-02T02:42:58+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
     <image:image>
@@ -11,7 +11,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/alojamiento.html</loc>
-    <lastmod>2026-03-22T13:44:40+00:00</lastmod>
+    <lastmod>2026-04-01T14:18:14-05:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -20,7 +20,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/cata.html</loc>
-    <lastmod>2026-03-21T18:54:08+00:00</lastmod>
+    <lastmod>2026-03-26T17:33:10+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -29,7 +29,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/catalogo.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T17:50:43+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -38,7 +38,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/coliving.html</loc>
-    <lastmod>2026-03-22T13:44:40+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -46,8 +46,17 @@
     </image:image>
   </url>
   <url>
+    <loc>https://termopilas.co/despierta.html</loc>
+    <lastmod>2026-04-20T19:31:55.643Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+    <image:image>
+      <image:loc>https://termopilas.co/assets/images/tour/header.png</image:loc>
+    </image:image>
+  </url>
+  <url>
     <loc>https://termopilas.co/pago.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -56,7 +65,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/salon.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -65,7 +74,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/tour.html</loc>
-    <lastmod>2026-03-22T13:44:40+00:00</lastmod>
+    <lastmod>2026-03-26T17:23:10+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <image:image>
@@ -74,7 +83,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/privacidad.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
     <image:image>
@@ -83,7 +92,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/registro.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
     <image:image>
@@ -92,7 +101,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/whatsapp.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
     <image:image>
@@ -101,7 +110,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/cata/cata-vino-paella-tapas-main.html</loc>
-    <lastmod>2026-02-19T21:27:20+00:00</lastmod>
+    <lastmod>2026-03-23T13:52:15+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -110,7 +119,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/cata/experiencia-vino-mar-fuego-fallido.html</loc>
-    <lastmod>2026-02-07T12:49:11-05:00</lastmod>
+    <lastmod>2026-03-23T13:52:15+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -119,7 +128,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/cata/experiencia-vino-mar-fuego-gracias.html</loc>
-    <lastmod>2026-02-07T12:49:11-05:00</lastmod>
+    <lastmod>2026-03-23T13:52:15+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -128,7 +137,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/cata/experiencia-vino-mar-fuego.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-23T13:52:15+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -137,7 +146,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/cata/index.html</loc>
-    <lastmod>2026-03-23T13:49:30.830Z</lastmod>
+    <lastmod>2026-03-26T17:23:10+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -146,7 +155,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/eventos/parrillada/gracias.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-23T13:52:15+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -155,7 +164,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/eventos/parrillada/index.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-26T17:23:10+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
     <image:image>
@@ -164,7 +173,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/trabajo/cocinero.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
@@ -173,7 +182,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/trabajo/conserje.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
@@ -182,7 +191,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/trabajo/recepcionista.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
@@ -191,7 +200,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/trabajo/web-developer.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
     <image:image>
@@ -200,7 +209,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/blog.html</loc>
-    <lastmod>2026-03-11T22:27:59+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -209,7 +218,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/cata-vinos.html</loc>
-    <lastmod>2026-02-19T21:27:20+00:00</lastmod>
+    <lastmod>2026-03-23T13:52:15+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -218,7 +227,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/feedback.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -227,7 +236,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/galeria.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -236,7 +245,16 @@
   </url>
   <url>
     <loc>https://termopilas.co/offline.html</loc>
-    <lastmod>2026-03-23T13:49:36.732Z</lastmod>
+    <lastmod>2026-03-23T13:52:15+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://termopilas.co/assets/images/header.png</image:loc>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://termopilas.co/parrilla.html</loc>
+    <lastmod>2026-03-26T17:33:10+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -245,7 +263,16 @@
   </url>
   <url>
     <loc>https://termopilas.co/terminos.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+    <image:image>
+      <image:loc>https://termopilas.co/assets/images/header.png</image:loc>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://termopilas.co/test-popup-automated.html</loc>
+    <lastmod>2026-04-02T02:57:07.110Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -254,7 +281,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/trabajo.html</loc>
-    <lastmod>2026-03-22T13:44:40+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>
@@ -263,7 +290,7 @@
   </url>
   <url>
     <loc>https://termopilas.co/ubicacion.html</loc>
-    <lastmod>2026-03-22T05:03:39+00:00</lastmod>
+    <lastmod>2026-03-24T15:56:46+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
     <image:image>


### PR DESCRIPTION
## Summary
- Adds `despierta.html` redirect page → `https://eventos.termopilas.co/despierta` → event 14 (*Despierta Tu Ser*), matching the existing `/cata`, `/tour`, `/parrilla`, `/coliving` vanity URLs.
- Registers `despierta.html` in the sitemap generator (`scripts/generate-sitemap.js`) and the PWA service-worker cache (`service-worker.js`).
- Regenerates `sitemap.xml` (now includes `/despierta.html` with priority 0.9).

Second hop is already live in `cecabrera/selfhost` (Caddy snippet `HiEventsVanityRedirects`): `https://eventos.termopilas.co/despierta` → 302 → `/event/14/despierta-tu-ser`.

## Test plan
- [ ] Merge triggers GitHub Pages deploy
- [ ] `curl -sI https://termopilas.co/despierta` returns 200 with `Content-Type: text/html`
- [ ] Browser hitting `https://termopilas.co/despierta` is redirected to `https://eventos.termopilas.co/event/14/despierta-tu-ser`
- [ ] `sitemap.xml` at `https://termopilas.co/sitemap.xml` includes `https://termopilas.co/despierta.html`