### PR TITLE
feat: add /eventos vanity URL → eventos.termopilas.co

### DIFF
--- a/eventos.html
+++ b/eventos.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="es-CO">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Eventos Finca Termópilas - Redirigiendo...</title>
+
+    <!-- Redirect via meta refresh (GitHub Pages doesn't support .htaccess) -->
+    <meta http-equiv="refresh" content="0; url=https://eventos.termopilas.co">
+    <link rel="canonical" href="https://eventos.termopilas.co">
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://termopilas.co/eventos.html">
+    <meta property="og:title" content="Eventos - Finca Termópilas">
+    <meta property="og:description" content="Descubre todos los eventos, catas, tours y experiencias próximas en Finca Termópilas, Rivera, Huila.">
+    <meta property="og:image" content="https://termopilas.co/assets/images/eventos/header.png">
+
+    <!-- Twitter -->
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://termopilas.co/eventos.html">
+    <meta property="twitter:title" content="Eventos - Finca Termópilas">
+    <meta property="twitter:description" content="Descubre todos los eventos, catas, tours y experiencias próximas en Finca Termópilas, Rivera, Huila.">
+    <meta property="twitter:image" content="https://termopilas.co/assets/images/eventos/header.png">
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-2406CNRCX9"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-2406CNRCX9');
+    </script>
+
+    <!-- Meta Pixel Code -->
+    <script>
+        !function(f,b,e,v,n,t,s)
+        {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+        n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+        if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+        n.queue=[];t=b.createElement(e);t.async=!0;
+        t.src=v;s=b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t,s)}(window, document,'script',
+        'https://connect.facebook.net/en_US/fbevents.js');
+        fbq('init', '760911966545667');
+        fbq('track', 'PageView');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+    src="https://www.facebook.com/tr?id=760911966545667&ev=PageView&noscript=1"
+    /></noscript>
+
+    <!-- Favicon -->
+    <link rel="icon" href="assets/images/favicon.png" type="image/png">
+
+    <!-- PWA Manifest -->
+    <link rel="manifest" href="/manifest.json">
+    <meta name="theme-color" content="#F29F05">
+
+    <!-- Apple Touch Icon -->
+    <link rel="apple-touch-icon" href="/assets/images/icons/apple-touch-icon.png">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="Termópilas">
+
+    <!-- Microsoft Tiles -->
+    <meta name="msapplication-TileColor" content="#F29F05">
+    <meta name="msapplication-TileImage" content="/assets/images/icons/icon-144x144.png">
+
+    <style>
+        body {
+            font-family: 'Montserrat', sans-serif;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+            background: linear-gradient(135deg, #F29F05 0%, #B8791C 100%);
+            color: white;
+            text-align: center;
+            padding: 20px;
+        }
+        .redirect-message {
+            max-width: 600px;
+        }
+        h1 {
+            font-size: 2rem;
+            margin-bottom: 1rem;
+        }
+        p {
+            font-size: 1.2rem;
+            margin-bottom: 2rem;
+        }
+        .spinner {
+            border: 4px solid rgba(255, 255, 255, 0.3);
+            border-radius: 50%;
+            border-top: 4px solid white;
+            width: 50px;
+            height: 50px;
+            animation: spin 1s linear infinite;
+            margin: 0 auto;
+        }
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+        a {
+            color: white;
+            text-decoration: underline;
+            font-weight: bold;
+        }
+    </style>
+</head>
+<body>
+    <div class="redirect-message">
+        <h1>Eventos Finca Termópilas</h1>
+        <p>Redirigiendo a nuestra página de eventos...</p>
+        <div class="spinner"></div>
+        <p style="margin-top: 2rem; font-size: 1rem;">
+            Si no eres redirigido automáticamente,
+            <a href="https://eventos.termopilas.co">haz clic aquí</a>
+        </p>
+    </div>
+
+    <script>
+        window.location.replace('https://eventos.termopilas.co');
+    </script>
+</body>
+</html>

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -30,6 +30,7 @@ const PRIMARY_PAGES = new Set([
   'catalogo.html',
   'cata.html',
   'despierta.html',
+  'eventos.html',
   'pago.html',
 ]);
 
@@ -130,6 +131,7 @@ const PAGE_IMAGE_MAP = {
   'catalogo.html': 'assets/images/catalog/header.png',
   'cata.html': 'assets/images/tour/tour-wine.jpg',
   'despierta.html': 'assets/images/tour/header.png',
+  'eventos.html': 'assets/images/eventos/header.png',
   'pago.html': 'assets/images/pago/wompi.png',
   'galeria.html': 'assets/images/galeria/galeria-01.jpeg',
   'blog.html': 'assets/images/blog/header.png',

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // Finca Termópilas - Service Worker
-const CACHE_NAME = 'termopilas-cache-v2026.04.01.223418';
+const CACHE_NAME = 'termopilas-cache-v2026.04.21.221026';
 const urlsToCache = [
   '/',
   '/alojamiento.html',
@@ -16,6 +16,7 @@ const urlsToCache = [
   '/coliving/gracias.html',
   '/despierta.html',
   '/dist/main.js',
+  '/eventos.html',
   '/feedback.html',
   '/galeria.html',
   '/index.html',

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://termopilas.co/</loc>
-    <lastmod>2026-04-02T02:42:58+00:00</lastmod>
+    <lastmod>2026-04-01T22:34:49+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
     <image:image>
@@ -47,11 +47,20 @@
   </url>
   <url>
     <loc>https://termopilas.co/despierta.html</loc>
-    <lastmod>2026-04-20T19:31:55.643Z</lastmod>
+    <lastmod>2026-04-20T20:07:03+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
     <image:image>
       <image:loc>https://termopilas.co/assets/images/tour/header.png</image:loc>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://termopilas.co/eventos.html</loc>
+    <lastmod>2026-03-21T13:26:13-05:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+    <image:image>
+      <image:loc>https://termopilas.co/assets/images/eventos/header.png</image:loc>
     </image:image>
   </url>
   <url>


### PR DESCRIPTION
## Summary

- Adds `termopilas.co/eventos.html` as a branded meta-refresh + JS redirect to `https://eventos.termopilas.co`, matching the existing vanity-URL pattern (`despierta`, `parrilla`, `cata`).
- Registers the new page in the sitemap generator (`PRIMARY_PAGES` and `PAGE_IMAGE_MAP`) using `assets/images/eventos/header.png`.
- Caches `/eventos.html` in the service worker and bumps `CACHE_NAME` so clients invalidate and pick up the new page.
- Regenerates `sitemap.xml` (now 34 URLs).

Context: previously this redirect page lived (unused) in the `selfhost` repo under `projects/termopilas/caddy/eventos.html`. It didn't belong there — the Caddy container never mounted or served it, and vanity redirects on the apex domain are a website concern. This PR moves it to its proper home and brings it up to the current redirect-page convention (GA, Meta Pixel, OG tags, spinner UI).

## Test plan

- [ ] Verify `https://termopilas.co/eventos.html` (after deploy) redirects to `https://eventos.termopilas.co` via both meta refresh and JS fallback.
- [ ] Confirm the OG preview renders with `assets/images/eventos/header.png` on Facebook/WhatsApp sharing debuggers.
- [ ] Confirm `sitemap.xml` contains the `/eventos.html` entry.
- [ ] Confirm the service worker updates to the new `CACHE_NAME` on next load.